### PR TITLE
Avoid intercepting the engine map command

### DIFF
--- a/AdminPlus.Commands.cs
+++ b/AdminPlus.Commands.cs
@@ -66,7 +66,7 @@ public partial class AdminPlus
         LoadInstalledMaps();
 
         AddCommand("kick", Localizer["Kick.Usage"], CmdKick);
-        AddCommand("map", Localizer["Map.Usage"], CmdChangeMap);
+        // Avoid intercepting the engine/server startup command, e.g. "+map de_cache".
         AddCommand("css_map", Localizer["Map.Usage"], CmdChangeMapClientOnly);
         AddCommand("wsmap", Localizer["Map.Usage"], CmdChangeWorkshopMap);
         AddCommand("workshop", Localizer["Map.Usage"], CmdChangeWorkshopMap);


### PR DESCRIPTION
﻿## Summary

This removes the bare `map` command registration and keeps the admin map command available through `css_map`.

## Why

Some CS2 server panels start servers with a fallback map, for example:

```text
+map de_cache +host_workshop_map <workshop_id>
```

Because AdminPlus registered a bare `map` command, the plugin could handle that startup `+map` command and later run `changelevel de_cache`. That can override the workshop map selected through `host_workshop_map`.

Using only `css_map` avoids intercepting the engine/server startup command while keeping the in-game admin command available.
